### PR TITLE
added node-typescript to packages user should install

### DIFF
--- a/tech/installation.md
+++ b/tech/installation.md
@@ -25,7 +25,7 @@ If you do not have these dependencies installed on your machine, we have instruc
 
 ```
 sudo apt-get update
-sudo apt-get install g++ make git python
+sudo apt-get install g++ make git python node-typescript
 curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash
 sudo apt-get install -y nodejs
 ```


### PR DESCRIPTION
Not only does ./compile bark if you don't have it, its explicitly required in this document at line 18